### PR TITLE
feat: add Supabase environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,8 @@ yarn-error.log*
 *.sln
 
 # local .env files
-.env
-.env.local*
+.env.dev
+.env.prod
 
 # MCP
 .cursor/mcp.json

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,5 +3,7 @@ declare namespace NodeJS {
     NODE_ENV: string;
     VUE_ROUTER_MODE: 'hash' | 'history' | 'abstract' | undefined;
     VUE_ROUTER_BASE: string | undefined;
+    SUPABASE_URL: string;
+    SUPABASE_KEY: string;
   }
 }


### PR DESCRIPTION
Adds the `SUPABASE_URL` and `SUPABASE_KEY` environment variables to the
`NodeJS.ProcessEnv` type in the `src/env.d.ts` file. This allows the
application to access the Supabase URL and API key from the environment.

Additionally, the `.gitignore` file is updated to ignore the `.env.dev` and
`.env.prod` files instead of the generic `.env` file. This ensures that
environment-specific configuration files are not accidentally committed to
the repository.