### PR TITLE
feat: Add Vercel deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 # MCP
 .cursor/mcp.json
+.vercel

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev",
     "build": "quasar build",
-    "postinstall": "quasar prepare"
+    "postinstall": "quasar prepare",
+    "deploy": "quasar build && vercel --prod"
   },
   "dependencies": {
     "@quasar/extras": "^1.16.4",

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -52,7 +52,10 @@ export default defineConfig((/* ctx */) => {
 
       // publicPath: '/',
       // analyze: true,
-      // env: {},
+      env: {
+        SUPABASE_URL: process.env.SUPABASE_URL,
+        SUPABASE_KEY: process.env.SUPABASE_KEY,
+      },
       // rawDefine: {}
       // ignorePublicFolder: true,
       // minify: false,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "routes": [
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/.*",
+      "dest": "/"
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a Vercel deployment configuration to the project. The
changes include:

- Adding a `.vercel` directory to the `.gitignore` file to exclude it
  from version control.
- Adding a `deploy` script to the `package.json` file to build the
  project and deploy it to Vercel.
- Adding a `vercel.json` file to configure the Vercel deployment,
  including routing rules to handle the Quasar application.

These changes will enable the project to be easily deployed to Vercel,
a popular cloud hosting platform, allowing for faster and more
efficient deployment of the application.