### PR TITLE
feat: Add .vercelignore file to exclude directories

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,4 @@
+/supabase
+/memory-bank
+/.cursor
+/.github


### PR DESCRIPTION
Adds a .vercelignore file to exclude the following directories from
Vercel deployments:

- /supabase
- /memory-bank
- /.cursor
- /.github

This ensures that these directories, which are not necessary for the
application to run, are not included in the deployment, reducing the
overall size and improving deployment performance.